### PR TITLE
Prayer Timer for Ramadan Porch

### DIFF
--- a/admin/admin-menu-and-tabs.php
+++ b/admin/admin-menu-and-tabs.php
@@ -231,7 +231,7 @@ class P4_Ramadan_Porch_Landing_Tab_Home {
                         <td><label for="field_key_<?php echo esc_html( $key )?>_translation-<?php echo esc_html( $val['language'] )?>"><?php echo esc_html( $val['native_name'] )?></label></td>
                         <?php if ( $field["type"] === "textarea" ) :?>
                             <td><textarea name="field_key_<?php echo esc_html( $key )?>_translation-<?php echo esc_html( $val['language'] )?>"><?php echo wp_kses_post( $field["translations"][$val['language']] ?? "" );?></textarea></td>
-                        <?php else: ?>
+                        <?php else : ?>
                             <td><input name="field_key_<?php echo esc_html( $key )?>_translation-<?php echo esc_html( $val['language'] )?>" type="text" value="<?php echo esc_html( $field["translations"][$val['language']] ?? "" );?>"/></td>
                         <?php endif; ?>
                     </tr>
@@ -243,7 +243,7 @@ class P4_Ramadan_Porch_Landing_Tab_Home {
 
     public function main_column() {
         global $allowed_tags;
-        $allowed_tags['script'] =  array(
+        $allowed_tags['script'] = array(
             'async' => array(),
             'src' => array()
         );
@@ -283,7 +283,7 @@ class P4_Ramadan_Porch_Landing_Tab_Home {
                 foreach ( $fields as $field_key => $field ){
                     if ( isset( $field["translations"] ) ){
                         foreach ( $langs as $lang_code => $lang_values ){
-                            if ( isset ( $post_fields["field_key_" . $field_key . "_translation-" . $lang_code] ) ){
+                            if ( isset( $post_fields["field_key_" . $field_key . "_translation-" . $lang_code] ) ){
                                 $saved_fields[$field_key]["translations"][$lang_code] = $post_fields["field_key_" . $field_key . "_translation-" . $lang_code];
                             }
                         }
@@ -357,6 +357,23 @@ class P4_Ramadan_Porch_Landing_Tab_Home {
                                     <?php if ( isset( $field["translations"] ) ){
                                         self::translation_cell( $langs, $key, $field );
                                     } ?>
+                                </td>
+                            </tr>
+                        <?php elseif ( 'prayer_timer_toggle' === $field['type'] ) : ?>
+                            <tr>
+                                <td>
+                                    <?php echo esc_html( $field['label'] ); ?>
+                                </td>
+                                <td>
+                                    <select name="list[<?php echo esc_html( $key ); ?>]">
+                                    <?php if ( $field['value'] === 'yes' || ! isset( $field['value'] ) || empty( $field['value'] ) ) : ?>
+                                        <option value="yes" selected="selected"><?php echo esc_html( __( 'Yes', 'pray4ramadan-porch' ) ); ?></option>
+                                        <option value="no"><?php echo esc_html( __( 'No', 'pray4ramadan-porch' ) ); ?></option>
+                                    <?php else : ?>
+                                        <option value="yes"><?php echo esc_html( __( 'Yes', 'pray4ramadan-porch' ) ); ?></option>
+                                        <option value="no" selected="selected"><?php echo esc_html( __( 'No', 'pray4ramadan-porch' ) ); ?></option>
+                                    <?php endif; ?>
+                                    </select>
                                 </td>
                             </tr>
                         <?php elseif ( 'theme_select' === $field['type'] ) : ?>
@@ -487,7 +504,7 @@ class P4_Ramadan_Porch_Landing_Tab_Starter_Content {
         ", ARRAY_A);
         $installed_langs = [];
         foreach ( $installed_langs_query as $result ){
-            if ( $result["meta_value"] === NULL ){
+            if ( $result["meta_value"] === null ){
                 $result["meta_value"] = 'en_US';
             }
             if ( !isset( $installed_langs[$result["meta_value"]] ) ){

--- a/pray4ramadan-porch.php
+++ b/pray4ramadan-porch.php
@@ -118,7 +118,7 @@ class P4_Ramadan_Porch {
         if ( isset( $fields['theme_color']['value'] ) && ! empty( $fields['theme_color']['value'] ) && ! defined( 'PORCH_COLOR_SCHEME' ) ) {
             $theme = $fields['theme_color']['value'];
             $hex = $fields['theme_color']['value'];
-            switch ( $theme_name ) {
+            switch ( $theme ) {
                 case 'preset':
                     $hex = '#4676fa';
                     break;

--- a/pray4ramadan-porch.php
+++ b/pray4ramadan-porch.php
@@ -117,8 +117,29 @@ class P4_Ramadan_Porch {
         $hex = '#4676fa';
         if ( isset( $fields['theme_color']['value'] ) && ! empty( $fields['theme_color']['value'] ) && ! defined( 'PORCH_COLOR_SCHEME' ) ) {
             $theme = $fields['theme_color']['value'];
-            $hex = p4r_get_theme_hex( $fields['theme_color']['value'] );
+            $hex = $fields['theme_color']['value'];
+            switch ( $theme_name ) {
+                case 'preset':
+                    $hex = '#4676fa';
+                    break;
+                case 'forestgreen':
+                    $hex = '#1EB858';
+                    break;
+                case 'green':
+                    $hex = '#94C523';
+                    break;
+                case 'orange':
+                    $hex = '#F57D41';
+                    break;
+                case 'purple':
+                    $hex = '#6B58CD';
+                    break;
+                case 'teal':
+                    $hex = '#1AB7D8';
+                    break;
+            }
         }
+
         if ( isset( $fields['custom_theme_color']['value'] ) && ! empty( $fields['custom_theme_color']['value'] ) ){
             $theme = 'custom';
             $hex = $fields['custom_theme_color']['value'];
@@ -322,35 +343,6 @@ add_action( 'plugins_loaded', function (){
         }
     }
 } );
-
-if ( ! function_exists( 'p4r_get_theme_hex' ) ) {
-    function p4r_get_theme_hex( $theme_name ) {
-        switch ( $theme_name ) {
-            case 'preset':
-                $hex = '#4676fa';
-                break;
-            case 'forestgreen':
-                $hex = '#1EB858';
-                break;
-            case 'green':
-                $hex = '#94C523';
-                break;
-            case 'orange':
-                $hex = '#F57D41';
-                break;
-            case 'purple':
-                $hex = '#6B58CD';
-                break;
-            case 'teal':
-                $hex = '#1AB7D8';
-                break;
-            default:
-                $hex = '#4676fa';
-                break;
-        }
-        return $hex;
-    }
-}
 
 if ( ! function_exists( 'p4r_porch_fields' ) ) {
     function p4r_porch_fields() {

--- a/pray4ramadan-porch.php
+++ b/pray4ramadan-porch.php
@@ -117,27 +117,7 @@ class P4_Ramadan_Porch {
         $hex = '#4676fa';
         if ( isset( $fields['theme_color']['value'] ) && ! empty( $fields['theme_color']['value'] ) && ! defined( 'PORCH_COLOR_SCHEME' ) ) {
             $theme = $fields['theme_color']['value'];
-            $hex = $fields['theme_color']['value'];
-            switch ( $theme ) {
-                case 'preset':
-                    $hex = '#4676fa';
-                    break;
-                case 'forestgreen':
-                    $hex = '#1EB858';
-                    break;
-                case 'green':
-                    $hex = '#94C523';
-                    break;
-                case 'orange':
-                    $hex = '#F57D41';
-                    break;
-                case 'purple':
-                    $hex = '#6B58CD';
-                    break;
-                case 'teal':
-                    $hex = '#1AB7D8';
-                    break;
-            }
+            $hex = p4r_get_theme_hex( $fields['theme_color']['value'] );
         }
         if ( isset( $fields['custom_theme_color']['value'] ) && ! empty( $fields['custom_theme_color']['value'] ) ){
             $theme = 'custom';
@@ -343,6 +323,35 @@ add_action( 'plugins_loaded', function (){
     }
 } );
 
+if ( ! function_exists( 'p4r_get_theme_hex' ) ) {
+    function p4r_get_theme_hex( $theme_name ) {
+        switch ( $theme_name ) {
+            case 'preset':
+                $hex = '#4676fa';
+                break;
+            case 'forestgreen':
+                $hex = '#1EB858';
+                break;
+            case 'green':
+                $hex = '#94C523';
+                break;
+            case 'orange':
+                $hex = '#F57D41';
+                break;
+            case 'purple':
+                $hex = '#6B58CD';
+                break;
+            case 'teal':
+                $hex = '#1AB7D8';
+                break;
+            default:
+                $hex = '#4676fa';
+                break;
+        }
+        return $hex;
+    }
+}
+
 if ( ! function_exists( 'p4r_porch_fields' ) ) {
     function p4r_porch_fields() {
         $defaults = [
@@ -389,11 +398,16 @@ if ( ! function_exists( 'p4r_porch_fields' ) ) {
                 'value' => trailingslashit( plugin_dir_url( __FILE__ ) ) . 'site/img/stencil-header.png',
                 'type' => 'text',
             ],
-
             'what_image' => [
                 'label' => 'What is Ramadan Image',
                 'value' => '',
                 'type' => 'text',
+            ],
+            'show_prayer_timer' => [
+                'label' => 'Show Prayer Timer',
+                'default' => __( 'Yes', 'pray4ramadan-porch' ),
+                'value' => 'yes',
+                'type' => 'prayer_timer_toggle',
             ],
             "email" => [
                 "label" => "Address to send sign-up and notification emails from",

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -88,7 +88,7 @@ if ( empty( $list->posts ) ){
                         <?php endforeach; ?>
                     </div>
                     <?php
-                    if ( isset ( $porch_fields['prayer_timer_toggle']['value'] ) && $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) :
+                    if ( isset( $porch_fields['show_prayer_timer']['value'] ) && $porch_fields['show_prayer_timer']['value'] === 'yes' ) :
                         if ( function_exists( 'show_prayer_timer' ) ) : ?>
                             <div class="mt-5">
                                 <?php show_prayer_timer( [ 'color' => PORCH_COLOR_SCHEME_HEX, 'duration' => 15] ); ?>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -88,18 +88,10 @@ if ( empty( $list->posts ) ){
                         <?php endforeach; ?>
                     </div>
                     <?php
-                    $hex = p4r_get_theme_hex( $porch_fields['theme_color']['value'] );
-
-                    // Check for custom theme hex
-                    if ( isset( $porch_fields['custom_theme_color']['value'] ) && ! empty( $porch_fields['custom_theme_color']['value'] ) ){
-                        $hex = $porch_fields['custom_theme_color']['value'];
-                    }
-
-
                     if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) :
                         if ( function_exists( 'show_prayer_timer' ) ) : ?>
                             <div class="mt-5">
-                                <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>
+                                <?php show_prayer_timer( [ 'color' => PORCH_COLOR_SCHEME_HEX, 'duration' => 15] ); ?>
                             </div>
                         <?php endif;
                     endif; ?>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -88,7 +88,7 @@ if ( empty( $list->posts ) ){
                         <?php endforeach; ?>
                     </div>
                     <?php
-                    if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) :
+                    if ( isset ( $porch_fields['prayer_timer_toggle']['value'] ) && $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) :
                         if ( function_exists( 'show_prayer_timer' ) ) : ?>
                             <div class="mt-5">
                                 <?php show_prayer_timer( [ 'color' => PORCH_COLOR_SCHEME_HEX, 'duration' => 15] ); ?>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -95,7 +95,7 @@ if ( empty( $list->posts ) ){
                         $hex = $porch_fields['custom_theme_color']['value'];
                     }
 
-                    if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) : ?>
+                    if ( $porch_fields['show_prayer_timer']['value'] === 'yes' ) : ?>
                     <div class="mt-5">
                         <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>
                     </div>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -24,7 +24,8 @@ if ( empty( $today->posts ) ){
                 'key'     => 'post_language',
                 'value'   => 'en_US',
                 'compare' => '=',
-            ],[
+            ],
+            [
                 'key'     => 'post_language',
                 'compare' => 'NOT EXISTS',
             ],
@@ -60,111 +61,14 @@ if ( empty( $list->posts ) ){
                 'key'     => 'post_language',
                 'value'   => 'en_US',
                 'compare' => '=',
-            ],[
+            ],
+            [
                 'key'     => 'post_language',
                 'compare' => 'NOT EXISTS',
             ],
         ]
     );
     $list = new WP_Query( $args );
-}
-
-function show_prayer_timer() {
-    ?>
-        <style>
-            .prayer-timer-container {
-                text-align: center;
-                margin-top: 25px;
-            }
-
-            .prayer-timer-clock {
-                width: 256px;
-                height: 256px;
-                background-color: #40598dAD;
-                border-radius: 50%;
-                border: 2.5px solid black;
-                display: inline-block;
-                overflow: hidden;
-                position: relative;
-                text-align: center;
-            }
-
-            .prayer-timer-slot {
-                width: 75%;
-                height: 51.6%;
-                clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-                transform-origin: top;
-                margin: 50% 12%;
-                position: absolute;
-            }
-
-            .slot-1 {
-                transform: rotate(0deg);
-                background: #40598d99;
-            }
-            .slot-2 {
-                transform: rotate(72deg);
-                background: #40598dCC;
-            }
-            .slot-3 {
-                transform: rotate(144deg);
-                background: #40598d;
-            }
-            .slot-4 {
-                transform: rotate(216deg);
-                background: #40598d33;
-            }
-            .slot-5 {
-                transform: rotate(288deg);
-                background: #40598d66;
-            }
-
-            .needle {
-                position: absolute;
-                width: 1.25%;
-                height: 45%;
-                background: black;
-                margin: 49%;
-                z-index: 1;
-                transform-origin: bottom;
-                top: -44%;
-            }
-
-            .prayer-timer-button-container {
-                width: 100%;
-            }
-
-            .start-praying {
-                position: relative;
-                margin: 11.1% 33.3%;
-            }
-
-            .rotate {
-                -webkit-transition:-webkit-transform 900s linear;
-                transform: rotate(360deg);
-            }
-        </style>
-        <br>
-        <h3 id="prayer-timer">PRAYER TIMER</h3>
-        <div class="prayer-timer-container">
-            <div class="prayer-timer-clock">
-                <div class="needle" id="needle" data-degrees="0"></div>
-                <div class="prayer-timer-slot slot-1"></div>
-                <div class="prayer-timer-slot slot-2"></div>
-                <div class="prayer-timer-slot slot-3"></div>
-                <div class="prayer-timer-slot slot-4"></div>
-                <div class="prayer-timer-slot slot-5"></div>
-            </div>
-            <div class="prayer-timer-button-container">
-                <a href="javascript:start_timer();" class="btn btn-common btn-rm" id="start-praying">Start Praying!</a>
-            </div>
-        </div>
-        <script>
-            function start_timer() {
-                jQuery( '.needle' ).attr( 'class', 'needle rotate' );
-            }
-        </script>
-    <?php
 }
 ?>
 
@@ -183,9 +87,13 @@ function show_prayer_timer() {
                             <?php echo wp_kses_post( $item->post_content ) ?>
                         <?php endforeach; ?>
                     </div>
-                    <div>
-                        <?php show_prayer_timer(); ?>
+                    <?php
+                    $hex = p4r_get_theme_hex( $porch_fields['theme_color']['value'] );
+                    if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) : ?>
+                    <div class="mt-5">
+                        <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>
                     </div>
+                    <?php endif; ?>
                 </div>
             </div>
         </div>
@@ -264,7 +172,7 @@ function show_prayer_timer() {
                     <p>
                         Made with &#10084;&#65039; by <a href="https://pray4movement.org">Pray4Movement.org</a><br>
                         Powered by <a href="https://disciple.tools">Disciple.Tools</a><br>
-                        &copy;  <?php echo esc_html ( date("Y") ); ?>
+                        &copy;  <?php echo esc_html( date( "Y" ) ); ?>
                     </p>
                 </div>
                 <div class="site-info wow fadeInUp" data-wow-duration="1000ms" data-wow-delay="0.3s">

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -89,6 +89,12 @@ if ( empty( $list->posts ) ){
                     </div>
                     <?php
                     $hex = p4r_get_theme_hex( $porch_fields['theme_color']['value'] );
+
+                    // Check for custom theme hex
+                    if ( isset( $porch_fields['custom_theme_color']['value'] ) && ! empty( $porch_fields['custom_theme_color']['value'] ) ){
+                        $hex = $porch_fields['custom_theme_color']['value'];
+                    }
+
                     if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) : ?>
                     <div class="mt-5">
                         <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -69,10 +69,104 @@ if ( empty( $list->posts ) ){
     $list = new WP_Query( $args );
 }
 
+function show_prayer_timer() {
+    ?>
+        <style>
+            .prayer-timer-container {
+                text-align: center;
+                margin-top: 25px;
+            }
+
+            .prayer-timer-clock {
+                width: 256px;
+                height: 256px;
+                background-color: #40598dAD;
+                border-radius: 50%;
+                border: 2.5px solid black;
+                display: inline-block;
+                overflow: hidden;
+                position: relative;
+                text-align: center;
+            }
+
+            .prayer-timer-slot {
+                width: 75%;
+                height: 51.6%;
+                clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+                transform-origin: top;
+                margin: 50% 12%;
+                position: absolute;
+            }
+
+            .slot-1 {
+                transform: rotate(0deg);
+                background: #40598d99;
+            }
+            .slot-2 {
+                transform: rotate(72deg);
+                background: #40598dCC;
+            }
+            .slot-3 {
+                transform: rotate(144deg);
+                background: #40598d;
+            }
+            .slot-4 {
+                transform: rotate(216deg);
+                background: #40598d33;
+            }
+            .slot-5 {
+                transform: rotate(288deg);
+                background: #40598d66;
+            }
+
+            .needle {
+                position: absolute;
+                width: 1.25%;
+                height: 45%;
+                background: black;
+                margin: 49%;
+                z-index: 1;
+                transform-origin: bottom;
+                top: -44%;
+            }
+
+            .prayer-timer-button-container {
+                width: 100%;
+            }
+
+            .start-praying {
+                position: relative;
+                margin: 11.1% 33.3%;
+            }
+
+            .rotate {
+                -webkit-transition:-webkit-transform 900s linear;
+                transform: rotate(360deg);
+            }
+        </style>
+        <br>
+        <h3 id="prayer-timer">PRAYER TIMER</h3>
+        <div class="prayer-timer-container">
+            <div class="prayer-timer-clock">
+                <div class="needle" id="needle" data-degrees="0"></div>
+                <div class="prayer-timer-slot slot-1"></div>
+                <div class="prayer-timer-slot slot-2"></div>
+                <div class="prayer-timer-slot slot-3"></div>
+                <div class="prayer-timer-slot slot-4"></div>
+                <div class="prayer-timer-slot slot-5"></div>
+            </div>
+            <div class="prayer-timer-button-container">
+                <a href="javascript:start_timer();" class="btn btn-common btn-rm" id="start-praying">Start Praying!</a>
+            </div>
+        </div>
+        <script>
+            function start_timer() {
+                jQuery( '.needle' ).attr( 'class', 'needle rotate' );
+            }
+        </script>
+    <?php
+}
 ?>
-
-
-
 
 <!-- TODAYS POST Section -->
 <section id="contact" class="section">
@@ -88,6 +182,9 @@ if ( empty( $list->posts ) ){
                         <?php foreach ($today->posts as $item ) : ?>
                             <?php echo wp_kses_post( $item->post_content ) ?>
                         <?php endforeach; ?>
+                    </div>
+                    <div>
+                        <?php show_prayer_timer(); ?>
                     </div>
                 </div>
             </div>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -95,11 +95,13 @@ if ( empty( $list->posts ) ){
                         $hex = $porch_fields['custom_theme_color']['value'];
                     }
 
-                    if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) : ?>
-                    <div class="mt-5">
-                        <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>
-                    </div>
-                    <?php endif; ?>
+                    if ( $porch_fields['prayer_timer_toggle']['value'] === 'yes' ) :
+                        if ( function_exists( 'show_prayer_timer' ) ) : ?>
+                            <div class="mt-5">
+                                <?php show_prayer_timer( [ 'color' => $hex, 'duration' => 15] ); ?>
+                            </div>
+                        <?php endif;
+                    endif; ?>
                 </div>
             </div>
         </div>

--- a/site/archive-body.php
+++ b/site/archive-body.php
@@ -88,7 +88,7 @@ if ( empty( $list->posts ) ){
                         <?php endforeach; ?>
                     </div>
                     <?php
-                    if ( isset( $porch_fields['show_prayer_timer']['value'] ) && $porch_fields['show_prayer_timer']['value'] === 'yes' ) :
+                    if ( isset( $porch_fields['show_prayer_timer']['value'] ) && ( $porch_fields['show_prayer_timer']['value'] === 'yes' ) || empty( $porch_fields['show_prayer_timer']['value'] ) ) :
                         if ( function_exists( 'show_prayer_timer' ) ) : ?>
                             <div class="mt-5">
                                 <?php show_prayer_timer( [ 'color' => PORCH_COLOR_SCHEME_HEX, 'duration' => 15] ); ?>


### PR DESCRIPTION
Adding the DT Prayer Campaign's Prayer Timer to the P4R Porch.

### Toggle between showing Prayer Timer or not (on by default)
<img width="540" alt="Screen Shot 2022-03-10 at 18 29 40" src="https://user-images.githubusercontent.com/36511666/157757970-7cc0b622-d305-4d4b-9fe3-586bef914732.png">


### Prayer Timer color matches theme color
<img width="540" alt="Screen Shot 2022-03-10 at 18 30 16" src="https://user-images.githubusercontent.com/36511666/157758052-088d9812-41ad-4804-bd16-1fb1089e984d.png">


### Prayer Timer color is compatible with custom theme colors
<img width="540" alt="Screen Shot 2022-03-10 at 18 31 30" src="https://user-images.githubusercontent.com/36511666/157758210-dcfdef49-517a-4282-9bb6-08cf20469e97.png">

